### PR TITLE
[BE/REFACTOR] 객체 참조 다 끊고 id 참조로 변경

### DIFF
--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/Book.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/Book.java
@@ -29,8 +29,4 @@ public class Book {
     private String imageURL;
     // 도서 관련 정보
     private String information;
-
-    @OneToMany
-    @JoinColumn(name = "book_categories")
-    private List<BookCategory> bookCategories;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/BookCategory.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/BookCategory.java
@@ -13,9 +13,10 @@ public class BookCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
-    // 카테고리 다대일
-    @ManyToOne
-    @JoinColumn(name = "category_id")
-    private Category category;
+
+    @Column(name = "book_id")
+    private Long bookId;
+
+    @Column(name = "category_id")
+    private Long BookId;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/BookDetail.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/book/domain/BookDetail.java
@@ -17,8 +17,6 @@ public class BookDetail {
     private boolean borrowStatus;
     private boolean reserveStatus;
 
-    // 도서 대다일
-    @ManyToOne
-    @JoinColumn(name = "book_id")
-    private Book book;
+    @Column(name = "book_id")
+    private Long bookId;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/bookBorrow/domain/BookBorrow.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/bookBorrow/domain/BookBorrow.java
@@ -22,16 +22,9 @@ public class BookBorrow {
     // 대출 연장 횟수
     private Integer extendCount;
 
-    // 유저 다대일
-//    @ManyToOne
-//    @JoinColumn(name = "user_id")
-//    private User user;
     @Column(name = "user_id")
     private Long userId;
-    // 도서 정보 다대일
-//    @ManyToOne
-//    @JoinColumn(name = "bookDetail_id")
-//    private BookDetail bookDetail;
+
     @Column(name = "bookDetail_id")
     private Long bookDetailId;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/bookBorrow/domain/BookReserve.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/bookBorrow/domain/BookReserve.java
@@ -14,14 +14,10 @@ public class BookReserve {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 유저 다대일
-//    @ManyToOne
-//    @JoinColumn(name = "user_id")
-//    private User user;
     @Column(name = "user_id")
     private Long userId;
     // 도서 대출/반납 일대일
-    @OneToOne
-    @JoinColumn(name = "bookBorrow_id")
-    private BookBorrow bookBorrow;
+
+    @Column(name = "bookBorrow_id")
+    private Long bookBorrowId;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/user/domain/Penalty.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/user/domain/Penalty.java
@@ -18,8 +18,6 @@ public class Penalty {
     // 대출/반납 제한 만료일자
     private LocalDate expiryDate;
 
-    // 유저 일대일
-    @OneToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id")
+    private Long userId;
 }

--- a/BE/chackcheck/src/main/java/sigma/chackcheck/domain/user/domain/User.java
+++ b/BE/chackcheck/src/main/java/sigma/chackcheck/domain/user/domain/User.java
@@ -16,6 +16,7 @@ public class User {
     private Long id;
     private String loginId;
     private String password;
+    private String name;
     // 기수
     private Integer grade;
     // 대출 유무


### PR DESCRIPTION
## #️⃣연관된 이슈
#47 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> N+1문제를 피할 때 fetch join을 사용하는데 페이지네이션과 fetch join을 쓰면 limit과 offset이 원하는대로 작동하지 않는다. 그래서 그냥 객체 참조를 다 끊기로 결정.

## 💬리뷰 요구사항(선택)
